### PR TITLE
feat Redux Store & Simple Login

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -9,8 +9,8 @@
     "build": "next build && next-sitemap && next export",
     "test": "eslint './**/*.js' && tsc --build",
     "lint": "yarn lint:ts",
-    "lint:ts": "tsc --noEmit && eslint '{pages,components,hooks,content}/**/*.{js,ts,tsx}' --max-warnings=0",
-    "lint:ts:fix": "eslint '{pages,components,hooks,content}/**/*.{js,ts,tsx}' --fix --max-warnings=0",
+    "lint:ts": "tsc --noEmit && eslint '{pages,components,hooks,content,store}/**/*.{js,ts,tsx}' --max-warnings=0",
+    "lint:ts:fix": "eslint '{pages,components,hooks,content,store}/**/*.{js,ts,tsx}' --fix --max-warnings=0",
     "storybook": "start-storybook -p 9000",
     "build-storybook": "build-storybook"
   },
@@ -25,7 +25,9 @@
     "react-dom": "17.0.2",
     "react-dropzone": "11.3.4",
     "react-markdown": "6.0.2",
+    "react-redux": "7.2.6",
     "react-syntax-highlighter": "11.0.3",
+    "redux": "4.1.2",
     "remark-slug": "6.1.0",
     "web3.storage": "^3.0.0"
   },
@@ -69,10 +71,10 @@
     }
   },
   "lint-staged": {
-    "{pages,components,hooks,content,styles}/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
+    "{pages,components,hooks,content,styles,store}/**/*.{js,jsx,ts,tsx,json,css,scss,md}": [
       "prettier --write"
     ],
-    "{pages,components,hooks,content}/**/!(types.tsx).{js,ts,tsx}": [
+    "{pages,components,hooks,content,store}/**/!(types.tsx).{js,ts,tsx}": [
       "eslint --fix --max-warnings=0"
     ]
   }

--- a/packages/website/pages/_app.tsx
+++ b/packages/website/pages/_app.tsx
@@ -1,8 +1,18 @@
 import '../styles/global.scss';
+import { Provider } from 'react-redux';
+
+import withAuthorizedReduxStore from '../store/store';
 
 /**
  * App root Component
  */
-export default function App({ Component, pageProps }: any) {
-  return <Component {...pageProps} />;
-}
+
+const App = ({ Component, store, pageProps }: any) => {
+  return (
+    <Provider store={store}>
+      <Component {...pageProps} />
+    </Provider>
+  );
+};
+
+export default withAuthorizedReduxStore(App);

--- a/packages/website/pages/_app.tsx
+++ b/packages/website/pages/_app.tsx
@@ -1,7 +1,8 @@
 import '../styles/global.scss';
 import { Provider } from 'react-redux';
 
-import withAuthorizedReduxStore from '../store/store';
+import withAuthorization from '../store/withAuthorization';
+import withReduxStore from '../store/store';
 
 /**
  * App root Component
@@ -15,4 +16,4 @@ const App = ({ Component, store, pageProps }: any) => {
   );
 };
 
-export default withAuthorizedReduxStore(App);
+export default withAuthorization(withReduxStore(App));

--- a/packages/website/pages/account/index.tsx
+++ b/packages/website/pages/account/index.tsx
@@ -1,13 +1,15 @@
 import { useAppSelector } from 'store';
 
-const TestPage: React.FC = () => {
+const Account: React.FC = () => {
   const { firstName, lastName } = useAppSelector(({ userData }) => userData!);
 
   return (
     <div>
-      {firstName}:{lastName}
+      firstname: {firstName}
+      <br />
+      lastname: {lastName}
     </div>
   );
 };
 
-export default TestPage;
+export default Account;

--- a/packages/website/pages/login/index.module.scss
+++ b/packages/website/pages/login/index.module.scss
@@ -1,3 +1,7 @@
 .login-container {
   background: blue;
 }
+
+.error {
+  border: 1px solid red;
+}

--- a/packages/website/pages/login/index.tsx
+++ b/packages/website/pages/login/index.tsx
@@ -1,30 +1,65 @@
 import clsx from 'clsx';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import styles from './index.module.scss';
 import { useAppDispatch } from 'store';
-import { setAuthToken } from 'store/actions';
+import { getUserData, setAuthToken } from 'store/actions';
 
 const Login = () => {
-  const { push } = useRouter();
-  // const { useDispatch } = use();
+  // App wide methods
   const dispatch = useAppDispatch();
+  const { push } = useRouter();
 
+  // Error states
+  const [errors, setErrors] = useState<{ user?: boolean; password?: boolean }>({});
+
+  // User form data binding
   const [{ user, password }, setFormData] = useState<{ user?: string; password?: string }>({});
+
+  // Callback for submission
+  const onSubmit = useCallback(
+    async e => {
+      e.preventDefault();
+
+      // Errors for empty fields
+      if (!user || !password) {
+        setErrors({ user: !user, password: !password });
+        return false;
+      }
+
+      // Setting auth token
+      const {
+        payload: { authentication },
+      } = await dispatch(await setAuthToken(user, password));
+
+      // Getting user data
+      await dispatch(await getUserData(authentication));
+
+      // Redirecting to account page
+      push('/account');
+    },
+    [dispatch, password, push, user]
+  );
 
   return (
     <div className={clsx(styles['login-container'])}>
-      <input placeholder="user" onChange={e => setFormData({ user: e.target.value, password })} />
-      <input placeholder="password" type="password" onChange={e => setFormData({ user, password: e.target.value })} />
-      <input
-        type="button"
-        value="Login"
-        onClick={async () => {
-          await dispatch(await setAuthToken(user, password));
-          push('/test');
-        }}
-      />
+      <form>
+        <input
+          placeholder="user"
+          className={clsx(errors.user && styles.error)}
+          required
+          onChange={e => setFormData({ user: e.target.value, password })}
+        />
+        <input
+          placeholder="password"
+          required
+          type="password"
+          onChange={e => setFormData({ user, password: e.target.value })}
+          className={clsx(errors.password && styles.error)}
+        />
+        <input type="submit" value="Login" onClick={onSubmit} />
+      </form>
     </div>
   );
 };

--- a/packages/website/pages/login/index.tsx
+++ b/packages/website/pages/login/index.tsx
@@ -1,7 +1,32 @@
 import clsx from 'clsx';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
 
 import styles from './index.module.scss';
+import { useAppDispatch } from 'store';
+import { setAuthToken } from 'store/actions';
 
-const Login = () => <div className={clsx(styles['login-container'])}>TODO: Login</div>;
+const Login = () => {
+  const { push } = useRouter();
+  // const { useDispatch } = use();
+  const dispatch = useAppDispatch();
+
+  const [{ user, password }, setFormData] = useState<{ user?: string; password?: string }>({});
+
+  return (
+    <div className={clsx(styles['login-container'])}>
+      <input placeholder="user" onChange={e => setFormData({ user: e.target.value, password })} />
+      <input placeholder="password" type="password" onChange={e => setFormData({ user, password: e.target.value })} />
+      <input
+        type="button"
+        value="Login"
+        onClick={async () => {
+          await dispatch(await setAuthToken(user, password));
+          push('/test');
+        }}
+      />
+    </div>
+  );
+};
 
 export default Login;

--- a/packages/website/pages/test/index.tsx
+++ b/packages/website/pages/test/index.tsx
@@ -1,0 +1,13 @@
+import { useAppSelector } from 'store';
+
+const TestPage: React.FC = () => {
+  const { firstName, lastName } = useAppSelector(({ userData }) => userData!);
+
+  return (
+    <div>
+      {firstName}:{lastName}
+    </div>
+  );
+};
+
+export default TestPage;

--- a/packages/website/store/actions.ts
+++ b/packages/website/store/actions.ts
@@ -1,7 +1,7 @@
 import { StoreAction } from 'store';
 
 export const setAuthToken = async (user?: string, password?: string) => {
-  // TODO: Async method to API to get user authentication token
+  // TODO: Async method to API to get user authentication token and properly store in cookie
   const authentication = `${user}:${password}`;
   document.cookie = `authorization=${authentication}; expires=${new Date(
     Number.MAX_SAFE_INTEGER

--- a/packages/website/store/actions.ts
+++ b/packages/website/store/actions.ts
@@ -1,0 +1,24 @@
+import { StoreAction } from 'store';
+
+export const setAuthToken = async (user?: string, password?: string) => {
+  // TODO: Async method to API to get user authentication token
+  const authentication = `${user}:${password}`;
+  document.cookie = `authorization=${authentication}; expires=${new Date(
+    Number.MAX_SAFE_INTEGER
+  ).getUTCDate()}; path=/;`;
+
+  return {
+    type: StoreAction.SET_AUTHENTICATION,
+    payload: { authentication },
+  };
+};
+
+export const getUserData = async auth => {
+  // TODO: Async method to API to get user data based off of auth token
+  const userData = !!auth ? { firstName: auth.split(':')[0], lastName: auth.split(':')[1] } : '';
+
+  return {
+    type: StoreAction.SET_USER_DATA,
+    payload: userData,
+  };
+};

--- a/packages/website/store/index.ts
+++ b/packages/website/store/index.ts
@@ -1,17 +1,20 @@
 import { useDispatch, TypedUseSelectorHook, useSelector } from 'react-redux';
 
+// Available Actions
 export enum StoreAction {
   SET_USER_DATA = 'SET_USER_DATA',
   SET_AUTHENTICATION = 'SET_AUTHENTICATION',
 }
 
+// Redux state shape
 export type AppReduxState = {
   authorization?: string;
-  userData?: {
+  userData: {
     firstName: string;
     lastName: string;
-  };
+  } | null;
 };
 
+// Custom typed hooks
 export const useAppDispatch = () => useDispatch();
 export const useAppSelector: TypedUseSelectorHook<AppReduxState> = useSelector;

--- a/packages/website/store/index.ts
+++ b/packages/website/store/index.ts
@@ -1,0 +1,17 @@
+import { useDispatch, TypedUseSelectorHook, useSelector } from 'react-redux';
+
+export enum StoreAction {
+  SET_USER_DATA = 'SET_USER_DATA',
+  SET_AUTHENTICATION = 'SET_AUTHENTICATION',
+}
+
+export type AppReduxState = {
+  authorization?: string;
+  userData?: {
+    firstName: string;
+    lastName: string;
+  };
+};
+
+export const useAppDispatch = () => useDispatch();
+export const useAppSelector: TypedUseSelectorHook<AppReduxState> = useSelector;

--- a/packages/website/store/reducers.ts
+++ b/packages/website/store/reducers.ts
@@ -1,0 +1,25 @@
+import { combineReducers } from 'redux';
+
+import { StoreAction } from 'store';
+
+const authentication = (state = {}, action) => {
+  if (action.type === StoreAction.SET_AUTHENTICATION) {
+    return {
+      ...state,
+      ...action.payload,
+    };
+  }
+  return state;
+};
+
+const userData = (state = {}, action) => {
+  if (action.type === StoreAction.SET_USER_DATA) {
+    return {
+      ...state,
+      ...action.payload,
+    };
+  }
+  return state;
+};
+
+export default combineReducers({ authentication, userData });

--- a/packages/website/store/store.tsx
+++ b/packages/website/store/store.tsx
@@ -1,0 +1,87 @@
+import React, { Component } from 'react';
+import Router from 'next/router';
+import { createStore } from 'redux';
+
+import reducers from './reducers';
+import { AppReduxState } from '.';
+import { getUserData } from './actions';
+
+const __NEXT_REDUX_STORE__ = '__NEXT_REDUX_STORE__';
+
+const getOrCreateStore = (initialState: AppReduxState = {}) => {
+  // Always make a new store if server, otherwise state is shared between requests
+  if (typeof window === 'undefined') {
+    return createStore(reducers, initialState);
+  }
+
+  // Create store if unavailable on the client and set it on the window object
+  if (!window[__NEXT_REDUX_STORE__]) {
+    window[__NEXT_REDUX_STORE__] = createStore(reducers, initialState);
+  }
+  return window[__NEXT_REDUX_STORE__];
+};
+
+const redirectToLogin = (res, storeState) => {
+  if (res) {
+    // On the server, we'll use an HTTP response to
+    // redirect with the status code of our choice.
+    // 307 is for temporary redirects.
+    res.writeHead(307, { Location: '/login' });
+    res.end();
+  } else {
+    // On the client, we'll use the Router-object
+    // from the 'next/router' module.
+    Router.replace('/login');
+  }
+  return storeState;
+};
+
+export default function withAuthorizedReduxStore(App) {
+  return class AppWithRedux extends Component<{
+    initialAppState?: AppReduxState;
+  }> {
+    static async getInitialProps(appContext) {
+      const {
+        ctx: { res, req, pathname },
+      } = appContext;
+      const pageProps = { ...(await App.getInitialProps?.(appContext)) };
+
+      const authCookie = !!req ? req.cookies.authorization : document.cookie.split('authorization=')[1]?.split(';')[0];
+
+      // Early return on the login page
+      if (pathname.indexOf('/login') >= 0) {
+        return pageProps;
+      }
+
+      // Get or Create the store with `undefined` as initialState
+      const store = getOrCreateStore();
+
+      // Initial authorization check for non login routes
+      if (!authCookie) {
+        return redirectToLogin(res, pageProps);
+      }
+
+      // Provide the store to getInitialProps of pages
+      appContext.ctx.store = store;
+
+      // get data here
+      const userData = await getUserData(authCookie);
+
+      if (!userData.payload) {
+        // Secondary unauthorized access check, redirecting to login
+        return redirectToLogin(res, pageProps);
+      }
+
+      store.dispatch(userData);
+
+      return {
+        ...pageProps,
+        initialAppState: store.getState(),
+      };
+    }
+
+    render() {
+      return <App {...this.props} store={getOrCreateStore({ ...this.props.initialAppState })} />;
+    }
+  };
+}

--- a/packages/website/store/withAuthorization.tsx
+++ b/packages/website/store/withAuthorization.tsx
@@ -1,0 +1,75 @@
+import React, { Component } from 'react';
+import Router from 'next/router';
+
+import { getOrCreateStore } from './store';
+import { getUserData } from './actions';
+import { AppReduxState } from 'store';
+
+const redirectToLogin = (res, storeState) => {
+  if (res) {
+    // On the server, we'll use an HTTP response to
+    // redirect with the status code of our choice.
+    // 307 is for temporary redirects.
+    res.writeHead(307, { Location: '/login' });
+    res.end();
+  } else {
+    // On the client, we'll use the Router-object
+    // from the 'next/router' module.
+    Router.replace('/login');
+  }
+  return storeState;
+};
+
+/**
+ * Wrapper that initializes with authorization, setting user data if not applicable
+ */
+export default function withAuthorization(App) {
+  return class AppWithAuthorization extends Component<{ appState: AppReduxState }> {
+    static async getInitialProps(appContext) {
+      const {
+        ctx: { res, req, pathname },
+      } = appContext;
+
+      // Initializing props
+      const pageProps = { ...(await App.getInitialProps?.(appContext)) };
+
+      // Getting any authentication cookies if available
+      const authCookie = !!req ? req.cookies.authorization : document.cookie.split('authorization=')[1]?.split(';')[0];
+
+      // Early return on the login page
+      if (pathname.indexOf('/login') >= 0) {
+        return pageProps;
+      }
+
+      // Initial authorization check for non login routes
+      if (!authCookie) {
+        return redirectToLogin(res, pageProps);
+      }
+
+      // Initializing store for the first time
+      const store = getOrCreateStore(pageProps.appState);
+
+      // store
+      if (!store.getState().userData) {
+        // Getting user data
+        const userData = await getUserData(authCookie);
+
+        if (!userData.payload) {
+          // Secondary unauthorized access check, redirecting to login
+          return redirectToLogin(res, pageProps);
+        }
+
+        store.dispatch(userData);
+      }
+
+      return {
+        ...pageProps,
+        appState: store.getState(),
+      };
+    }
+
+    render() {
+      return <App {...this.props} store={this.props.appState} />;
+    }
+  };
+}

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -20,7 +20,7 @@
     "noImplicitAny": false,
     "baseUrl": "."
   },
-  "include": ["lib", "pages", "components", "content", "hooks", "modules", "declaration.d.ts"],
+  "include": ["lib", "pages", "components", "content", "hooks", "modules", "store", "declaration.d.ts"],
   "exclude": ["node_modules/", ".next/", "{pages,components,content,hooks,modules}/**/*.js"],
   "references": [
     {


### PR DESCRIPTION

### Changes

- Adding in simple redux setup
- Adding in an authorization wrapper that tests against all pages except login (if "authorization" does not exist or if "getUserData" fails, redirects to login)
- Adding in a simple login page with forms

### Notes

- **IMPORTANT** There is no authorization at the moment, to get past the login logic simply put in anything to the user/password fields and click 'login'
