### PR TITLE
feat Accounts page layout and dummy blocks

### DIFF
--- a/packages/website/components/account/FilesManager.tsx
+++ b/packages/website/components/account/FilesManager.tsx
@@ -1,0 +1,11 @@
+import clsx from 'clsx';
+
+type FilesManagerProps = {
+  className?: string;
+};
+
+const FilesManager = ({ className }: FilesManagerProps) => {
+  return <div className={clsx('section files-manager-container', className)}>TODO: Files Manager Content</div>;
+};
+
+export default FilesManager;

--- a/packages/website/components/account/StorageManager.tsx
+++ b/packages/website/components/account/StorageManager.tsx
@@ -1,0 +1,11 @@
+import clsx from 'clsx';
+
+type StorageManagerProps = {
+  className?: string;
+};
+
+const StorageManager = ({ className }: StorageManagerProps) => {
+  return <div className={clsx('section storage-manager-container', className)}>TODO: Storage Manager Content</div>;
+};
+
+export default StorageManager;

--- a/packages/website/pages/account/index.scss
+++ b/packages/website/pages/account/index.scss
@@ -1,0 +1,52 @@
+.account-container {
+  max-width: 61.125rem;
+  margin: auto;
+
+  h3 {
+    padding: 0 1.75rem 0.75rem;
+  }
+}
+
+.account-content {
+  display: grid;
+  width: 100%;
+  grid-template-areas:
+    'storage-manager storage-manager upload-cta'
+    'tokens-cta docs-cta upload-cta'
+    'files-manager files-manager files-manager';
+
+  grid-template-columns: 1fr 1fr 1fr;
+  grid-gap: 0.6875rem 0.9375rem;
+
+  .account {
+    &-storage-manager {
+      grid-area: storage-manager;
+      height: 9rem; // TODO: Remove temporary height
+    }
+    &-upload-cta {
+      grid-area: upload-cta;
+      overflow: hidden;
+      position: relative;
+      background: $white;
+      border: none;
+    }
+    &-tokens-cta {
+      grid-area: tokens-cta;
+      height: 14.5rem; // TODO: Remove temporary height
+    }
+    &-docs-cta {
+      grid-area: docs-cta;
+      height: 14.5rem; // TODO: Remove temporary height
+    }
+    &-files-manager {
+      grid-area: files-manager;
+      min-height: 17.125rem; // TODO: Remove temporary height
+    }
+  }
+}
+
+.account-gradient-background {
+  position: absolute;
+  min-width: 36.625rem;
+  left: -40%;
+}

--- a/packages/website/pages/account/index.tsx
+++ b/packages/website/pages/account/index.tsx
@@ -1,13 +1,22 @@
-import { useAppSelector } from 'store';
+// import { useAppSelector } from 'store';
+
+import StorageManager from '../../components/account/StorageManager';
+import FilesManager from '../../components/account/FilesManager';
+import GradientBackground from 'assets/illustrations/gradient-background';
 
 const Account: React.FC = () => {
-  const { firstName, lastName } = useAppSelector(({ userData }) => userData!);
-
   return (
-    <div>
-      firstname: {firstName}
-      <br />
-      lastname: {lastName}
+    <div className="page-container account-container">
+      <h3>Account</h3>
+      <div className="account-content">
+        <StorageManager className="account-storage-manager" />
+        <div className="section account-tokens-cta">TODO: Tokens CTA Content</div>
+        <div className="section account-docs-cta">TODO: Docs CTA Content</div>
+        <div className="section account-upload-cta">
+          <GradientBackground className="account-gradient-background" />
+        </div>
+        <FilesManager className="account-files-manager" />
+      </div>
     </div>
   );
 };

--- a/packages/website/pages/account/index.tsx
+++ b/packages/website/pages/account/index.tsx
@@ -1,5 +1,3 @@
-// import { useAppSelector } from 'store';
-
 import StorageManager from '../../components/account/StorageManager';
 import FilesManager from '../../components/account/FilesManager';
 import GradientBackground from 'assets/illustrations/gradient-background';


### PR DESCRIPTION

### Changes
![image](https://user-images.githubusercontent.com/5040232/143976651-d015f68a-2756-4097-9a2f-85a7d530961b.png)

- Blocked out content for Accounts page
- Prep'ing custom component widgets

### Notes
- Using CSS grids
